### PR TITLE
Allow attribute value 0 when renderStructure

### DIFF
--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -91,7 +91,7 @@ class DOMSerializer {
       start = 2
       for (let name in attrs) {
         if (name == "style") dom.style.cssText = attrs[name]
-        else if (attrs[name]) dom.setAttribute(name, attrs[name])
+        else if (attrs[name] != null) dom.setAttribute(name, attrs[name])
       }
     }
     for (let i = start; i < structure.length; i++) {


### PR DESCRIPTION
When trying to generate `<progress max="100" value="0">`, value disappeared.