### PR TITLE
Correct documentation of Schema#markSpec

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -352,7 +352,7 @@ class Schema {
   constructor(spec) {
     // :: OrderedMap<NodeSpec> The node specs that the schema is based on.
     this.nodeSpec = OrderedMap.from(spec.nodes)
-    // :: OrderedMap<constructor<MarkType>> The mark spec that the schema is based on.
+    // :: OrderedMap<MarkSpec> The mark spec that the schema is based on.
     this.markSpec = OrderedMap.from(spec.marks)
 
     // :: Object<NodeType>


### PR DESCRIPTION
It seems to me that the documentation for `Schema#markSpec` incorrectly refers to `constructor<MarkType>` when it should be `MarkSpec`, as for the `nodeSpec` property.