### PR TITLE
Add support for parsing with namespaces

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -10,6 +10,11 @@ const {Mark} = require("./mark")
 //   A CSS selector describing the kind of DOM elements to match. A
 //   single rule should have _either_ a `tag` or a `style` property.
 //
+//   namespace:: ?string
+//   The namespace to match. This should be used with `tag`.
+//   Nodes are only matched when the namespace matches or this property
+//   is null.
+//
 //   style:: ?string
 //   A CSS property name to match. When given, this rule matches
 //   inline styles that list that property.
@@ -164,7 +169,7 @@ class DOMParser {
   matchTag(dom, context) {
     for (let i = 0; i < this.tags.length; i++) {
       let rule = this.tags[i]
-      if (matches(dom, rule.tag) && (!rule.context || context.matchesContext(rule.context))) {
+      if (matches(dom, rule.tag) && matchesNamespace(dom, rule.namespace) && (!rule.context || context.matchesContext(rule.context))) {
         if (rule.getAttrs) {
           let result = rule.getAttrs(dom)
           if (result === false) continue
@@ -173,6 +178,10 @@ class DOMParser {
         return rule
       }
     }
+  }
+
+  matchesNamespace(dom, namespace) {
+    return !namespace || dom.namespaceURI == namespace
   }
 
   matchStyle(prop, value, context) {

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -338,6 +338,36 @@ describe("DOMParser", () => {
       })
       ist(DOMParser.schemaRules(schema).map(r => r.tag).join(" "), "em bar foo i")
     })
+
+    function nsParse(doc) {
+      let schema = new Schema({
+        marks: {},
+        nodes: {doc: {content: "h*"}, text: {},
+                h: {parseDOM: [{tag: "h", namespace: "urn:ns"}]}}
+      })
+      return DOMParser.fromSchema(schema).parse(doc).content.content
+    }
+
+    it("includes nodes when namespace is correct", () => {
+      let doc = document.createElement("doc")
+      let h = document.createElementNS("urn:ns", "h")
+      doc.appendChild(h)
+      ist(nsParse(doc).length, 1)
+    })
+
+    it("excludes nodes when namespace is wrong", () => {
+      let doc = document.createElement("doc")
+      let h = document.createElementNS("urn:nt", "h")
+      doc.appendChild(h)
+      ist(nsParse(doc).length, 0)
+    })
+
+    it("excludes nodes when namespace is absent", () => {
+      let doc = document.createElement("doc")
+      let h = document.createElement("h")
+      doc.appendChild(h)
+      ist(nsParse(doc).length, 0)
+    })
   })
 })
 


### PR DESCRIPTION
Element.matches does not support namespace prefixes, so an extra
property on ParseRule is required to match against namespaces.

Unfortunately, JSDOM currently implements Element.matches differently from browser which makes the tests fail.
https://github.com/tmpvar/jsdom/issues/1846

