### PR TITLE
Fix parsing of elements with an empty namespace

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -170,7 +170,7 @@ class DOMParser {
     for (let i = 0; i < this.tags.length; i++) {
       let rule = this.tags[i]
       if (matches(dom, rule.tag) &&
-          (!rule.namespace || dom.namespaceURI == rule.namespace) &&
+          (rule.namespace === undefined || dom.namespaceURI == rule.namespace) &&
           (!rule.context || context.matchesContext(rule.context))) {
         if (rule.getAttrs) {
           let result = rule.getAttrs(dom)

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -343,10 +343,10 @@ describe("DOMParser", () => {
           ? (new (require("jsdom").JSDOM)("<tag/>", {contentType: "application/xml"})).window.document
           : window.document
 
-    function nsParse(doc) {
+    function nsParse(doc, namespace) {
       let schema = new Schema({
         nodes: {doc: {content: "h*"}, text: {},
-                h: {parseDOM: [{tag: "h", namespace: "urn:ns"}]}}
+                h: {parseDOM: [{tag: "h", namespace}]}}
       })
       return DOMParser.fromSchema(schema).parse(doc)
     }
@@ -355,21 +355,44 @@ describe("DOMParser", () => {
       let doc = xmlDocument.createElement("doc")
       let h = xmlDocument.createElementNS("urn:ns", "h")
       doc.appendChild(h)
-      ist(nsParse(doc).childCount, 1)
+      ist(nsParse(doc, "urn:ns").childCount, 1)
     })
 
     it("excludes nodes when namespace is wrong", () => {
       let doc = xmlDocument.createElement("doc")
       let h = xmlDocument.createElementNS("urn:nt", "h")
       doc.appendChild(h)
-      ist(nsParse(doc).childCount, 0)
+      ist(nsParse(doc, "urn:ns").childCount, 0)
     })
 
     it("excludes nodes when namespace is absent", () => {
       let doc = xmlDocument.createElement("doc")
-      let h = xmlDocument.createElement("h")
+      // in HTML documents, createElement gives namespace
+      // 'http://www.w3.org/1999/xhtml' so use createElementNS
+      let h = xmlDocument.createElementNS(null, "h")
       doc.appendChild(h)
-      ist(nsParse(doc).childCount, 0)
+      ist(nsParse(doc, "urn:ns").childCount, 0)
+    })
+
+    it("excludes nodes when namespace is wrong and xhtml", () => {
+      let doc = xmlDocument.createElement("doc")
+      let h = xmlDocument.createElementNS("urn:nt", "h")
+      doc.appendChild(h)
+      ist(nsParse(doc, "http://www.w3.org/1999/xhtml").childCount, 0)
+    })
+
+    it("excludes nodes when namespace is wrong and empty", () => {
+      let doc = xmlDocument.createElement("doc")
+      let h = xmlDocument.createElementNS("urn:nt", "h")
+      doc.appendChild(h)
+      ist(nsParse(doc, "").childCount, 0)
+    })
+
+    it("includes nodes when namespace is correct and empty", () => {
+      let doc = xmlDocument.createElement("doc")
+      let h = xmlDocument.createElementNS(null, "h")
+      doc.appendChild(h)
+      ist(nsParse(doc, null).childCount, 1)
     })
   })
 })


### PR DESCRIPTION
If namespace is undefined, it should not be checked. If it is null
the namespace is empty and only elements with empty namespace should
be parsed.