### PR TITLE
Allow parseRule context to be an array

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -610,10 +610,13 @@ class ParseContext {
     }
   }
 
-  // : (string) → bool
+  // : (string | [string]) → bool
   // Determines whether the given [context
-  // string](#ParseRule.context) matches this context.
+  // string](#ParseRule.context), or one of context strings, matches this context.
   matchesContext(context) {
+    if (Array.isArray(context)) {
+      return context.some(this.matchesContext, this);
+    }
     let parts = context.split("/")
     let option = this.options.context
     let useRoot = !this.isOpen && (!option || option.parent.type == this.nodes[0].type)


### PR DESCRIPTION
It looks natural to extend the possibilities offered by matchesContext.
I might be wrong in thinking so, though.