### PR TITLE
Preserve non-breaking space characters during import

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -377,7 +377,8 @@ class ParseContext {
     let top = this.top
     if ((top.type ? top.type.inlineContent : top.content.length && top.content[0].isInline) || /\S/.test(value)) {
       if (!(top.options & OPT_PRESERVE_WS)) {
-        value = value.replace(/\s+/g, " ")
+        // Replace all matches for "\s" except non-breaking space character \u00a0
+        value = value.replace(/[ \f\n\r\t\v\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+/g, " ")
         // If this starts with whitespace, and there is either no node
         // before it or a node that ends with whitespace, strip the
         // leading space.

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -115,6 +115,10 @@ describe("DOMParser", () => {
        recover(" <blockquote> <p>woo  \n  <em> hooo</em></p> </blockquote> ",
                doc(blockquote(p("woo ", em("hooo"))))))
 
+    it("preserves non-breaking spaces",
+       recover("consolidate these   spaces but not these\u00a0\u00a0\u00a0spaces",
+               doc(p("consolidate these spaces but not these\u00a0\u00a0\u00a0spaces"))))
+
     it("finds a valid place for invalid content",
        recover("<ul><li>hi</li><p>whoah</p><li>again</li></ul>",
                doc(ul(li(p("hi")), li(p("whoah")), li(p("again"))))))


### PR DESCRIPTION
Preserve non-breaking space characters \u00a0 the same way they are preserved by browsers when parsing an HTML document.