### PR TITLE
Fix type definition for Fragment::findDiffEnd

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -182,7 +182,7 @@ export class Fragment {
     return findDiffStart(this, other, pos)
   }
 
-  // :: (Node) → ?{a: number, b: number}
+  // :: (Fragment) → ?{a: number, b: number}
   // Find the first position, searching from the end, at which this
   // fragment and the given fragment differ, or `null` if they are the
   // same. Since this position will not be the same in both nodes, an


### PR DESCRIPTION
I think, according to the text description and usage in the footnotes demo, that the first parameter should be a Fragment rather than a Node.

https://github.com/ProseMirror/prosemirror-model/blob/c36944d413de5cd00960159d9f90997fbad2db33/src/fragment.js#L185-L192