### PR TITLE
handle marks on elements with content

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -278,13 +278,14 @@ function wsOptionsFor(preserveWhitespace) {
 }
 
 class NodeContext {
-  constructor(type, attrs, solid, match, options) {
+  constructor(type, attrs, solid, match, options, marks = Mark.none) {
     this.type = type
     this.attrs = attrs
     this.solid = solid
     this.match = match || (options & OPT_OPEN_LEFT ? null : type.contentMatch)
     this.options = options
     this.content = []
+    this.marks = marks
   }
 
   findWrapping(node) {
@@ -317,7 +318,7 @@ class NodeContext {
     let content = Fragment.from(this.content)
     if (!openEnd && this.match)
       content = content.append(this.match.fillBefore(Fragment.empty, true))
-    return this.type ? this.type.create(this.attrs, content) : content
+    return this.type ? this.type.create(this.attrs, content, this.marks) : content
   }
 }
 
@@ -536,12 +537,13 @@ class ParseContext {
 
   // Open a node of the given type
   enterInner(type, attrs, solid, preserveWS) {
+    let marks = this.marks
     this.closeExtra()
     let top = this.top
     top.match = top.match && top.match.matchType(type, attrs)
     let options = preserveWS == null ? top.options & ~OPT_OPEN_LEFT : wsOptionsFor(preserveWS)
     if ((top.options & OPT_OPEN_LEFT) && top.content.length == 0) options |= OPT_OPEN_LEFT
-    this.nodes.push(new NodeContext(type, attrs, solid, null, options))
+    this.nodes.push(new NodeContext(type, attrs, solid, null, options, marks))
     this.open++
   }
 

--- a/test/test-block-marks.js
+++ b/test/test-block-marks.js
@@ -1,0 +1,193 @@
+const ist = require("ist")
+const {DOMParser, DOMSerializer, Schema} = require("../dist")
+
+// declare global: window
+let document = typeof window == "undefined" ? (new (require("jsdom").JSDOM)).window.document : window.document
+
+const schema = new Schema({
+  marks: {
+    comment: {
+      attrs: {
+        id: {
+          default: 0
+        },
+        inline: {
+          default: true
+        }
+      },
+      parseDOM: [{
+          tag: "span.comment",
+          getAttrs(dom) {
+            return {
+              id: parseInt(dom.dataset.id),
+              inline: true
+            }
+          }
+        },
+        {
+          tag: "div.comment",
+          getAttrs(dom) {
+            return {
+              id: parseInt(dom.dataset.id),
+              inline: false
+            }
+          }
+        }
+      ],
+      toDOM(node) {
+        let elType = node.attrs.inline ? 'span' : 'div'
+        return [elType, {
+          'data-id': node.attrs.id
+        }]
+      }
+    }
+  },
+  nodes: {
+    doc: {
+      content: "block+",
+      marks: "comment"
+    },
+    paragraph: {
+      content: "inline*",
+      group: "block"
+    },
+    text: {
+      group: "inline"
+    }
+  }
+})
+
+const parser = DOMParser.fromSchema(schema)
+const serializer = DOMSerializer.fromSchema(schema)
+
+describe("BlockMarks", () => {
+  describe("parse", () => {
+    function domFrom(html) {
+      let dom = document.createElement("div")
+      dom.innerHTML = html
+      return dom
+    }
+
+    function test(html, json) {
+      return () => {
+        let doc = schema.nodeFromJSON(json)
+        let derivedDOM = document.createElement("div")
+        derivedDOM.appendChild(serializer.serializeFragment(doc.content, {document}))
+        let declaredDOM = domFrom(html)
+
+        ist(derivedDOM.innerHTML, declaredDOM.innerHTML)
+        ist(parser.parse(derivedDOM).toJSON(), json, eq)
+      }
+    }
+
+    it("can represent a mark on a block with no mark on contained text",
+      test(
+        "<p>This paragraph has no marks.</p><div class='comment' data-id='234'><p>This paragraph has a mark.</p></div>",
+        {
+          "type": "doc",
+          "content": [{
+            "type": "paragraph",
+            "content": [{
+              "type": "text",
+              "text": "This paragraph has no marks."
+            }]
+          }, {
+            "type": "paragraph",
+            "content": [{
+              "type": "text",
+              "text": "This paragraph has a mark."
+            }],
+            "marks": [{
+              "type": "comment",
+              "attrs": {
+                "id": 234
+              }
+            }]
+          }]
+        }
+      )
+    )
+
+    it("can represent a mark on a block with the same mark on contained text",
+      test(
+        "<p>This paragraph has no marks.</p><div class='comment' data-id='234'><p>This <span class='comment' data-id='234'>paragraph</span> has a mark.</p></div>",
+        {
+          "type": "doc",
+          "content": [{
+            "type": "paragraph",
+            "content": [{
+              "type": "text",
+              "text": "This paragraph has no marks."
+            }]
+          }, {
+            "type": "paragraph",
+            "content": [{
+              "type": "text",
+              "text": "This "
+            }, {
+              "type": "text",
+              "text": "paragraph",
+              "marks": [{
+                "type": "comment",
+                "attrs": {
+                  "id": 234
+                }
+              }]
+          }, {
+            "type": "text",
+            "text": " has a mark."
+          }],
+            "marks": [{
+              "type": "comment",
+              "attrs": {
+                "id": 234
+              }
+            }]
+          }]
+        }
+      )
+    )
+
+    it("can represent a mark on a block with the same mark on contained text with an attribute difference",
+      test(
+        "<p>This paragraph has no marks.</p><div class='comment' data-id='234'><p>This <span class='comment' data-id='235'>paragraph</span> has a mark.</p></div>",
+        {
+          "type": "doc",
+          "content": [{
+            "type": "paragraph",
+            "content": [{
+              "type": "text",
+              "text": "This paragraph has no marks."
+            }]
+          }, {
+            "type": "paragraph",
+            "content": [{
+              "type": "text",
+              "text": "This "
+            }, {
+              "type": "text",
+              "text": "paragraph",
+              "marks": [{
+                "type": "comment",
+                "attrs": {
+                  "id": 235
+                }
+              }]
+          }, {
+            "type": "text",
+            "text": " has a mark."
+          }],
+            "marks": [{
+              "type": "comment",
+              "attrs": {
+                "id": 234
+              }
+            }]
+          }]
+        }
+      )
+    )
+
+  })
+
+})


### PR DESCRIPTION
This is an attempt that works in a few examples I tried out. For some reason trying to use rollup locally results in an unusable dist file, so I was forced to make the changes directly in the ES5 version dist folder and here I recreate what I did here. Someone with more knowledge of the sources should take a look at it. Relates to https://github.com/ProseMirror/prosemirror/issues/780 .