### PR TITLE
Make return type of ResolvedPos.node optional

### DIFF
--- a/src/resolvedpos.js
+++ b/src/resolvedpos.js
@@ -38,7 +38,7 @@ export class ResolvedPos {
   // The root node in which the position was resolved.
   get doc() { return this.node(0) }
 
-  // :: (?number) → Node
+  // :: (?number) → ?Node
   // The ancestor node at the given level. `p.node(p.depth)` is the
   // same as `p.parent`.
   node(depth) { return this.path[this.resolveDepth(depth) * 3] }


### PR DESCRIPTION
`ResolvedPos.node` can actually return `undefined` for wrong `depth`.