### PR TITLE
extend toJSON Node.attrs from Object.prototype

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -337,7 +337,7 @@ export class Node {
   toJSON() {
     let obj = {type: this.type.name}
     for (let _ in this.attrs) {
-      obj.attrs = this.attrs
+      obj.attrs = Object.assign({}, this.attrs)
       break
     }
     if (this.content.size)


### PR DESCRIPTION
This handles some situations where exporting a Node with attributes via `Node.toJSON()` would fail somewhat strict definitions of what a "plain object" is (specifically, [implementations like this](https://github.com/firebase/firebase-js-sdk/blob/e441ffbb42bd24db8457ee89a1c8d6042f0d625e/packages/firestore/src/util/input_validation.ts#L284-L294), where the object is checked against the `Object.prototype`).