### PR TITLE
Support overriding toString method of a node from NodeSpec

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -272,6 +272,7 @@ export class Node {
   // Return a string representation of this node for debugging
   // purposes.
   toString() {
+    if (this.type.spec.toDebugString) return this.type.spec.toDebugString(this)
     let name = this.type.name
     if (this.content.size)
       name += "(" + this.content.toStringInner() + ")"
@@ -374,7 +375,10 @@ export class TextNode extends Node {
     this.text = content
   }
 
-  toString() { return wrapMarks(this.marks, JSON.stringify(this.text)) }
+  toString() {
+    if (this.type.spec.toDebugString) return this.type.spec.toDebugString(this)
+    return wrapMarks(this.marks, JSON.stringify(this.text))
+  }
 
   get textContent() { return this.text }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -396,6 +396,10 @@ export class MarkType {
 //   implied (the name of this node will be filled in automatically).
 //   If you supply your own parser, you do not need to also specify
 //   parsing rules in your schema.
+//
+//   toDebugString:: ?(node: Node) -> string
+//   Defines the default way a node of this type should be serialized
+//   to a string representation for debugging (e.g. in error messages).
 
 // MarkSpec:: interface
 //


### PR DESCRIPTION
Closes: https://github.com/ProseMirror/prosemirror/issues/810

I've added a few tests for this change, but also quite a few other tests are failing even in master. Haven't looked at why :) 