### PR TITLE
Node#inlineContent doc update

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -244,7 +244,7 @@ export class Node {
   get isTextblock() { return this.type.isTextblock }
 
   // :: bool
-  // True when this node has inline content.
+  // True when this node allows inline content.
   get inlineContent() { return this.type.inlineContent }
 
   // :: bool


### PR DESCRIPTION
A node's inlineContent property can be true even if it is empty and does not have any content.