### PR TITLE
fixed: avoid setting blank style attributes on all dom nodes

### DIFF
--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -126,9 +126,7 @@ export class DOMSerializer {
     if (attrs && typeof attrs == "object" && attrs.nodeType == null && !Array.isArray(attrs)) {
       start = 2
       for (let name in attrs) {
-        if (attrs[name] != null) {
-          dom.setAttribute(name, attrs[name])
-        }
+        if (attrs[name] != null) dom.setAttribute(name, attrs[name])
       }
     }
     for (let i = start; i < structure.length; i++) {

--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -126,8 +126,9 @@ export class DOMSerializer {
     if (attrs && typeof attrs == "object" && attrs.nodeType == null && !Array.isArray(attrs)) {
       start = 2
       for (let name in attrs) {
-        if (name == "style") dom.style.cssText = attrs[name]
-        else if (attrs[name] != null) dom.setAttribute(name, attrs[name])
+        if (attrs[name] != null) {
+          dom.setAttribute(name, attrs[name])
+        }
       }
     }
     for (let i = start; i < structure.length; i++) {


### PR DESCRIPTION
`prosemirror-model@1.6.3` when generating dom nodes does not include the `style` attribute in confirming it has a value before being set. This leads to all generated dom nodes having a blank style attribute when no value is provided.

# Example Issue
## Input
```
<p>Test paragraph</p>
```

## Spec
```
export const paragraph = {
  content: "inline*",
  group: "block",
  attrs: {
    style: { default: null } 
  },
  parseDOM: [
    {
      tag: "p",
      getAttrs(dom) {
        return {
          style: dom.getAttribute('style')
        }
      }
    }
  ],
  toDOM(node) {
    return ["p", node.attrs, 0];
  }
};
```

## Output
```
<p style="">Test paragraph</p>
```

---

- [X] existing tests are passing
- [X] code style maintained

I did not see away to add attributes to the test specs. I can work on figuring out a test if this is something you'd like in order to merge this change.

I also changed the style attribute to be set the same way as the others, using the `setAttribute` method. The techniques seem to be interchangeable per the [mdn docs, "`using elt.style.cssText = '...' or elt.setAttribute('style', '...')`" ](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) and [`setAttribute` has deep browser support](https://caniuse.com/#search=setAttribute).

Let me know if there is anything else I can provide.
