### PR TITLE
Implements spanning behaviour in DOMSerializer

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -429,6 +429,10 @@ export class MarkType {
 //   group:: ?string
 //   The group or space-separated groups to which this mark belongs.
 //
+//   spanning:: ?bool
+//   Determines whether marks of this type can span multiple adjacent
+//   nodes when serialized to DOM/HTML. Defaults to true.
+//
 //   toDOM:: ?(mark: Mark, inline: bool) → DOMOutputSpec
 //   Defines the default way marks of this type should be serialized
 //   to DOM/HTML. When the resulting spec contains a hole, that is

--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -52,7 +52,7 @@ export class DOMSerializer {
         while (keep < active.length && rendered < node.marks.length) {
           let next = node.marks[rendered]
           if (!this.marks[next.type.name]) { rendered++; continue }
-          if (!next.eq(active[keep])) break
+          if (!next.eq(active[keep]) || next.type.spec.spanning === false) break
           keep += 2; rendered++
         }
         while (keep < active.length) {


### PR DESCRIPTION
This PR implements spanning behaviour of marks in `DOMSerializer`. 

Please see https://github.com/ProseMirror/prosemirror-view/pull/43 for more context.