### PR TITLE
Export TextNode class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export {Node} from "./node"
+export {Node, TextNode} from "./node"
 export {ResolvedPos, NodeRange} from "./resolvedpos"
 export {Fragment} from "./fragment"
 export {Slice, ReplaceError} from "./replace"


### PR DESCRIPTION
If you need to check the marks at replace steps in all TextNodes, you can use recursive functions and check if its a Node or a TextNode with constructor.name, but using uglify-js (case of vue.js) it breaks the code, according to this thread (https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/269) a better idea should be use elem.constructor === Parent instead of element.construcot.name === 'Parent'. For this purpose you can import Node and TextNode and check.