### PR TITLE
fixes DOM parsing of unique, non-exclusive, same-type marks

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -530,7 +530,7 @@ class ParseContext {
   applyPendingMarks(top) {
     for (let i = 0; i < this.pendingMarks.length; i++) {
       let mark = this.pendingMarks[i]
-      if ((!top.type || top.type.allowsMarkType(mark.type)) && !mark.type.isInSet(top.activeMarks)) {
+      if ((!top.type || top.type.allowsMarkType(mark.type)) && !mark.isInSet(top.activeMarks)) {
         top.activeMarks = mark.addToSet(top.activeMarks)
         this.pendingMarks.splice(i--, 1)
       }

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -93,6 +93,31 @@ describe("DOMParser", () => {
            "<p>one</p><div class=\"comment\"><p>two</p><p><strong>three</strong></p></div><p>four</p>")()
     })
 
+    it("parses unique, non-exclusive, same-typed marks", () => {
+      let commentSchema = new Schema({
+        nodes: schema.spec.nodes,
+        marks: schema.spec.marks.update("comment", {
+          attrs: { id: { default: null }},
+          parseDOM: [{
+            tag: "span.comment",
+            getAttrs(dom) { return { id: parseInt(dom.getAttribute('data-id'), 10) } }
+          }],
+          excludes: '',
+          toDOM(mark) { return ["span", {class: "comment", "data-id": mark.attrs.id }, 0] }
+        })
+      })
+      let b = builders(commentSchema)
+      test(b.schema.nodes.doc.createAndFill(undefined, [
+          b.schema.nodes.paragraph.createAndFill(undefined, [
+            b.schema.text('double comment', [
+                b.schema.marks.comment.create({ id: 1 }),
+                b.schema.marks.comment.create({ id: 2 })
+              ])
+          ])
+        ]),
+           "<p><span class=\"comment\" data-id=\"1\"><span class=\"comment\" data-id=\"2\">double comment</span></span></p>")()
+    })
+
     it("serializes non-spanning marks correctly", () => {
       let markSchema = new Schema({
         nodes: schema.spec.nodes,


### PR DESCRIPTION
We were running into a bug where typing into a document with marks that are non-exclusive (e.g. you can have multiple of the same kind, provided they're unique) would wipe out all but one of the marks. The same was/is true of paste.

Demo of the bug here:
https://glitch.com/edit/#!/ethereal-trout?path=index.js:16:0
https://ethereal-trout.glitch.me/

I think this fix is straightforward (added a test) but there may be nuance to `MarkType.isInSet` vs. `Mark.isInSet` in this context that i'm not familiar with.