### PR TITLE
feat allow nested list type

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -400,7 +400,7 @@ class ParseContext {
   // none is found, the element's content nodes are added directly.
   addElement(dom) {
     let name = dom.nodeName.toLowerCase()
-    if (listTags.hasOwnProperty(name)) normalizeList(dom)
+    if (listTags.hasOwnProperty(name) && !this.options.nestedList) normalizeList(dom)
     let rule = (this.options.ruleFromNode && this.options.ruleFromNode(dom)) || this.parser.matchTag(dom, this)
     if (rule ? rule.ignore : ignoreTags.hasOwnProperty(name)) {
       this.findInside(dom)


### PR DESCRIPTION
In my editor，Multi-level list format is: 
```html
<ul>
    <li>A</li>
    <ul>
        <li>A-1</li>
    </ul>
</ul>
```
In this case, the current code can't meet my needs.
I hope there is a configuration that can improve the current situation.