### PR TITLE
Update comment for ResolvedPos.index()

### DIFF
--- a/src/resolvedpos.js
+++ b/src/resolvedpos.js
@@ -46,7 +46,7 @@ export class ResolvedPos {
   // :: (?number) → number
   // The index into the ancestor at the given level. If this points at
   // the 3rd node in the 2nd paragraph on the top level, for example,
-  // `p.index(0)` is 2 and `p.index(1)` is 3.
+  // `p.index(0)` is 1 and `p.index(1)` is 2.
   index(depth) { return this.path[this.resolveDepth(depth) * 3 + 1] }
 
   // :: (?number) → number


### PR DESCRIPTION
The index returned by ResolvedPos.index() should be zero based.

In the example

```
 // The index into the ancestor at the given level. If this points at
  // the 3rd node in the 2nd paragraph on the top level, for example,
  // `p.index(0)` is 2 and `p.index(1)` is 3.
  index(depth) { return this.path[this.resolveDepth(depth) * 3 + 1] }
```

`p.index(0)` should return 1, and `p.index(1)` should return 2.
