### PR TITLE
Improve ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.5",
   "description": "ProseMirror's document model",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "license": "MIT",
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git://github.com/prosemirror/prosemirror-model.git"
   },
   "dependencies": {
-    "orderedmap": "^1.0.0"
+    "orderedmap": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "ist": "^1.0.0",
     "jsdom": "^10.1.0",
     "prosemirror-test-builder": "^1.0.0",
-    "rollup": "^0.49.0",
-    "rollup-plugin-buble": "^0.15.0"
+    "rollup": "^1.26.3",
+    "@rollup/plugin-buble": "^0.20.0"
   },
   "scripts": {
     "test": "node etc/link-self.js && mocha test/test-*.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,12 @@
-module.exports = {
-  input: "./src/index.js",
-  output: {format: "cjs", file: "dist/index.js"},
-  sourcemap: true,
-  plugins: [require("rollup-plugin-buble")()],
+import buble from '@rollup/plugin-buble'
+
+export default {
+  input: './src/index.js',
+  output: {
+    dir: 'dist',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [buble()],
   external(id) { return !/^[\.\/]/.test(id) }
 }


### PR DESCRIPTION
Following the PR for [orderedmap](https://github.com/marijnh/orderedmap/pull/5), this one shows the changes I would like to introduce to support PM in buildless environments.

I took the opportunity to upgrade Rollup dependencies and improve the packaging by keeping only the required files.

PS: if you release _orderedmap_ as a new major version (although I think a minor version should be enough since no breaking changes are introduced) then the version defined in this package must be bumped. 