### PR TITLE
Updated documentation for `node` to handle undefined results

### DIFF
--- a/src/resolvedpos.js
+++ b/src/resolvedpos.js
@@ -38,9 +38,12 @@ export class ResolvedPos {
   // The root node in which the position was resolved.
   get doc() { return this.node(0) }
 
-  // :: (?number) → Node
+  // :: (?number) → ?Node
   // The ancestor node at the given level. `p.node(p.depth)` is the
   // same as `p.parent`.
+  // Negative values for `depth` return the ancestor node at the current
+  // depth minus the value.
+  // If no node exists at the resolved depth, it returns undefined
   node(depth) { return this.path[this.resolveDepth(depth) * 3] }
 
   // :: (?number) → number


### PR DESCRIPTION
* It's possible for this method to return `undefined`, which  is not currently documented
* `resolveDepth` accepts negative values, which is not currently documented

Example: 
```
x = state.doc.resolve(0)
x.node(1) // undefined
x.node(-1) // undefined
```