### PR TITLE
Add support to render XML namespace

### DIFF
--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -121,12 +121,9 @@ export class DOMSerializer {
       return {dom: doc.createTextNode(structure)}
     if (structure.nodeType != null)
       return {dom: structure}
-    let contentDOM = null
-    let [xmlns, tag] = structure[0].split(' ', 2)
-    if (!tag) {
-      tag = structure[0]
-      xmlns = parentXmlns
-    }
+    let contentDOM = null, xmlns = parentXmlns, tag
+    if (structure[0].indexOf(" ") > -1) [xmlns, tag] = structure[0].split(" ", 2)
+    else tag = structure[0]
     let dom = xmlns ? doc.createElementNS(xmlns, tag) : doc.createElement(tag)
     let attrs = structure[1], start = 1
     if (attrs && typeof attrs == "object" && attrs.nodeType == null && !Array.isArray(attrs)) {

--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -4,13 +4,12 @@
 // itself, or an array.
 //
 // An array describes a DOM element. The first value in the array
-// should be a string—the name of the DOM element. It also can be
-// space-separated the XML namespace and the name. If the second
-// element is plain object, it is interpreted as a set of attributes
-// for the element. Any elements after that (including the 2nd if it's
-// not an attribute object) are interpreted as children of the DOM
-// elements, and must either be valid `DOMOutputSpec` values, or the
-// number zero.
+// should be a string—the name of the DOM element, optionally prefixed
+// by a namespace URL and a space. If the second element is plain
+// object, it is interpreted as a set of attributes for the element.
+// Any elements after that (including the 2nd if it's not an attribute
+// object) are interpreted as children of the DOM elements, and must
+// either be valid `DOMOutputSpec` values, or the number zero.
 //
 // The number zero (pronounced “hole”) is used to indicate the place
 // where a node's child nodes should be inserted. If it occurs in an

--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -4,7 +4,8 @@
 // itself, or an array.
 //
 // An array describes a DOM element. The first value in the array
-// should be a string—the name of the DOM element. If the second
+// should be a string—the name of the DOM element. It also can be
+// space-separated the XML namespace and the name. If the second
 // element is plain object, it is interpreted as a set of attributes
 // for the element. Any elements after that (including the 2nd if it's
 // not an attribute object) are interpreted as children of the DOM
@@ -116,17 +117,31 @@ export class DOMSerializer {
   // Render an [output spec](#model.DOMOutputSpec) to a DOM node. If
   // the spec has a hole (zero) in it, `contentDOM` will point at the
   // node with the hole.
-  static renderSpec(doc, structure) {
+  static renderSpec(doc, structure, parentXmlns = null) {
     if (typeof structure == "string")
       return {dom: doc.createTextNode(structure)}
     if (structure.nodeType != null)
       return {dom: structure}
-    let dom = doc.createElement(structure[0]), contentDOM = null
+    let contentDOM = null
+    let [xmlns, tag] = structure[0].split(' ', 2)
+    if (!tag) {
+      tag = structure[0]
+      xmlns = parentXmlns
+    }
+    let dom = xmlns ? doc.createElementNS(xmlns, tag) : doc.createElement(tag)
     let attrs = structure[1], start = 1
     if (attrs && typeof attrs == "object" && attrs.nodeType == null && !Array.isArray(attrs)) {
       start = 2
       for (let name in attrs) {
-        if (attrs[name] != null) dom.setAttribute(name, attrs[name])
+        if (attrs[name] != null) {
+          let [xmlnsAttr, nameWithoutXmlns] = name.split(' ', 2)
+          if (nameWithoutXmlns) {
+            dom.setAttributeNS(xmlnsAttr, nameWithoutXmlns, attrs[name])
+          } else {
+            dom.setAttribute(name, attrs[name])
+          }
+
+        }
       }
     }
     for (let i = start; i < structure.length; i++) {
@@ -136,7 +151,7 @@ export class DOMSerializer {
           throw new RangeError("Content hole must be the only child of its parent node")
         return {dom, contentDOM: dom}
       } else {
-        let {dom: inner, contentDOM: innerContent} = DOMSerializer.renderSpec(doc, child)
+        let {dom: inner, contentDOM: innerContent} = DOMSerializer.renderSpec(doc, child, xmlns)
         dom.appendChild(inner)
         if (innerContent) {
           if (contentDOM) throw new RangeError("Multiple content holes")

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -27,7 +27,6 @@ describe("DOMParser", () => {
         let declaredDOM = domFrom(html, document_)
 
         ist(derivedDOM.innerHTML, declaredDOM.innerHTML)
-        console.log(derivedDOM.innerHTML);
         ist(DOMParser.fromSchema(schema).parse(derivedDOM), doc, eq)
       }
     }


### PR DESCRIPTION
This pull request will add support to render XML namespace with `toDOM` function.


# Usage


```javascript
toDOM(node) {
  return [
    'http://www.w3.org/2000/svg svg',
    ['use', { "http://www.w3.org/1999/xlink xlink:href": "#YOUR_SVG_ID" }]
  ]
}
```

This pull request will expand the first item of returned value of `toDOM` function.
It will receive space-separated string. The first one is XML namespace, and the second is element name.
We can also use XML namespace for attributes in the same way.


# related issue


* https://github.com/ProseMirror/prosemirror-model/pull/10
* https://discuss.prosemirror.net/t/how-to-render-svg-something/1737
* https://github.com/ProseMirror/prosemirror/issues/898


