### PR TITLE
Only allow supported marks when opening node of type

### DIFF
--- a/src/from_dom.js
+++ b/src/from_dom.js
@@ -569,7 +569,7 @@ class ParseContext {
     top.match = top.match && top.match.matchType(type, attrs)
     let options = preserveWS == null ? top.options & ~OPT_OPEN_LEFT : wsOptionsFor(preserveWS)
     if ((top.options & OPT_OPEN_LEFT) && top.content.length == 0) options |= OPT_OPEN_LEFT
-    this.nodes.push(new NodeContext(type, attrs, top.activeMarks, solid, null, options))
+    this.nodes.push(new NodeContext(type, attrs, top.activeMarks.filter(mark => type.allowsMarkType(mark)), solid, null, options))
     this.open++
   }
 

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -327,6 +327,9 @@ describe("DOMParser", () => {
        open("<div>foo</div><div><em>bar</em></div>",
             [p("foo"), p(em("bar"))], 1, 1))
 
+    it("will not apply invalid marks to nodes",
+      open("<ul style='font-weight: bold'><li>foo</li></ul>", [ul(li(p("foo")))], 3, 3))
+
     function find(html, doc) {
       return () => {
         let dom = document.createElement("div")


### PR DESCRIPTION
Fix for https://github.com/ProseMirror/prosemirror/issues/1022
