### PR TITLE
De-duplicate expressions in Slice.fromJSON

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -79,7 +79,7 @@ export class Slice {
     let openStart = json.openStart || 0, openEnd = json.openEnd || 0
     if (typeof openStart != "number" || typeof openEnd != "number")
       throw new RangeError("Invalid input for Slice.fromJSON")
-    return new Slice(Fragment.fromJSON(schema, json.content), json.openStart || 0, json.openEnd || 0)
+    return new Slice(Fragment.fromJSON(schema, json.content), openStart, openEnd)
   }
 
   // :: (Fragment, ?bool) → Slice


### PR DESCRIPTION
Replace the final `json.openStart || 0` with just `openStart` which already contains the result of that expression. Do the same with `openEnd`.

This is just a small redundant calculation that I stumbled upon while writing a collaborative editing authority and I figured it would be nice to send a patch. This shouldn't have any observable side effects, but just to be sure I followed the instructions in [`prosemirror`](https://github.com/prosemirror/prosemirror#setting-up-a-dev-environment), checked out this patch branch to the `model` subfolder and ran the tests, which worked flawlessly.

Thank you for this project and making it so easy to send in contributions.