### PR TITLE
Update docs for spec.marks and spec.nodes

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -299,7 +299,7 @@ export class MarkType {
 // An object describing a schema, as passed to the [`Schema`](#model.Schema)
 // constructor.
 //
-//   nodes:: union<Object<NodeSpec>, OrderedMap<NodeSpec>>
+//   nodes:: OrderedMap<NodeSpec>>
 //   The node types in this schema. Maps names to
 //   [`NodeSpec`](#model.NodeSpec) objects that describe the node type
 //   associated with that name. Their order is significant—it
@@ -307,7 +307,7 @@ export class MarkType {
 //   precedence by default, and which nodes come first in a given
 //   [group](#model.NodeSpec.group).
 //
-//   marks:: ?union<Object<MarkSpec>, OrderedMap<MarkSpec>>
+//   marks:: OrderedMap<MarkSpec>>
 //   The mark types that exist in this schema. The order in which they
 //   are provided determines the order in which [mark
 //   sets](#model.Mark.addToSet) are sorted and in which [parse


### PR DESCRIPTION
From the code I see schema.spec.marks and schema.spec.nodes are always OrderedMaps and the order(which plain objects doesn't maintain) is also required for executing parse rules. 

This is causing errors when used in typescript projects. Since this is used as reference for the types in definitely typed package.

Needs to be updated in definitely typed repo as well. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/prosemirror-model/index.d.ts#L1119. Will create a PR there after this.