### PR TITLE
Update docs to add includeParents flag of Node slice method

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -158,9 +158,11 @@ export class Node {
     return this.copy(this.content.cut(from, to))
   }
 
-  // :: (number, ?number) → Slice
+  // :: (number, ?number, ?bool) → Slice
   // Cut out the part of the document between the given positions, and
   // return it as a `Slice` object.
+  // `includeParents` if true will also include the parents of nodes
+  // between these positions. Defaults to false.
   slice(from, to = this.content.size, includeParents = false) {
     if (from == to) return Slice.empty
 


### PR DESCRIPTION
Updates docs to add missing flag.

N.B. to Typescript users, planning to open a PR for [the definition here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/prosemirror-model/index.d.ts#L592) if this is merged.