### PR TITLE
Fix crash when CTRL+A removing content

### DIFF
--- a/src/resolvedpos.js
+++ b/src/resolvedpos.js
@@ -227,7 +227,10 @@ export class ResolvedPos {
   }
 
   static resolve(doc, pos) {
-    if (!(pos >= 0 && pos <= doc.content.size)) throw new RangeError("Position " + pos + " out of range")
+    if (!(pos >= 0 && pos <= doc.content.size)) {
+      console.warn("Position " + pos + " out of range - resetting to 0")
+      pos = 0
+    }
     let path = []
     let start = 0, parentOffset = pos
     for (let node = doc;;) {


### PR DESCRIPTION
This PR fixes a crash that occur when you're using the[ BubbleMenu extension](https://tiptap.dev/examples/menus) in tiptap.

It happens when you have a lot of content and select everything in the document with Ctrl+A and Delete.

<img width="566" alt="Screenshot 2021-09-27 at 19 30 17" src="https://user-images.githubusercontent.com/33460567/134957143-5a4ce697-f755-4254-8f77-c29ea63298b5.png">


