### PR TITLE
Extend textBetween API by accepting function to stringify leaf nodes

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -40,7 +40,7 @@ export class Fragment {
     this.nodesBetween(0, this.size, f)
   }
 
-  // :: (number, number, ?string, ?string) → string
+  // :: (number, number, ?string, ?string | ?(leafNode: Node) -> string) → string
   // Extract the text between `from` and `to`. See the same method on
   // [`Node`](#model.Node.textBetween).
   textBetween(from, to, blockSeparator, leafText) {
@@ -50,7 +50,7 @@ export class Fragment {
         text += node.text.slice(Math.max(from, pos) - pos, to - pos)
         separated = !blockSeparator
       } else if (node.isLeaf && leafText) {
-        text += leafText
+        text += typeof leafText === 'function' ? leafText(node): leafText
         separated = !blockSeparator
       } else if (!separated && node.isBlock) {
         text += blockSeparator

--- a/src/node.js
+++ b/src/node.js
@@ -93,7 +93,7 @@ export class Node {
   // children.
   get textContent() { return this.textBetween(0, this.content.size, "") }
 
-  // :: (number, number, ?string, ?string) → string
+  // :: (number, number, ?string, ?string | ?(leafNode: Node) -> string) → string
   // Get all text between positions `from` and `to`. When
   // `blockSeparator` is given, it will be inserted whenever a new
   // block node is started. When `leafText` is given, it'll be


### PR DESCRIPTION
I think it would be nice if we could specify a function for each leaf node type instead of just using the same string for every node type. 

If you see merit in this idea, I can go ahead add tests.

