### PR TITLE
Prosemirror-Model: Add missing optional target argument to serializeFragment function

### DIFF
--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -36,7 +36,7 @@ export class DOMSerializer {
     this.marks = marks || {}
   }
 
-  // :: (Fragment, ?Object) → dom.DocumentFragment
+  // :: (Fragment, ?Object, dom.DocumentFragment) → dom.DocumentFragment
   // Serialize the content of this fragment to a DOM fragment. When
   // not in the browser, the `document` option, containing a DOM
   // document, should be passed so that the serializer can create

--- a/src/to_dom.js
+++ b/src/to_dom.js
@@ -36,7 +36,7 @@ export class DOMSerializer {
     this.marks = marks || {}
   }
 
-  // :: (Fragment, ?Object, dom.DocumentFragment) → dom.DocumentFragment
+  // :: (Fragment, ?Object, ?dom.Node) → dom.DocumentFragment
   // Serialize the content of this fragment to a DOM fragment. When
   // not in the browser, the `document` option, containing a DOM
   // document, should be passed so that the serializer can create


### PR DESCRIPTION
Adding missing optional "target" argument type to serializeFragment function as per issue raised in DefinitelyTyped repo (@types-prosemirror-model): 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57668 