### PR TITLE
Allow a leaf node to customize its textContent

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -57,9 +57,13 @@ export class Fragment {
       if (node.isText) {
         text += node.text!.slice(Math.max(from, pos) - pos, to - pos)
         separated = !blockSeparator
-      } else if (node.isLeaf && leafText) {
-        text += typeof leafText === 'function' ? leafText(node): leafText
-        separated = !blockSeparator
+      } else if (node.isLeaf) {
+        if (leafText) {
+          text += typeof leafText === "function" ? leafText(node) : leafText;
+        } else if (node.type.spec.toText) {
+          text += node.type.spec.toText(node);
+        }
+        separated = !blockSeparator;
       } else if (!separated && node.isBlock) {
         text += blockSeparator
         separated = true

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -60,8 +60,8 @@ export class Fragment {
       } else if (node.isLeaf) {
         if (leafText) {
           text += typeof leafText === "function" ? leafText(node) : leafText;
-        } else if (node.type.spec.toText) {
-          text += node.type.spec.toText(node);
+        } else if (node.type.spec.leafText) {
+          text += node.type.spec.leafText(node);
         }
         separated = !blockSeparator;
       } else if (!separated && node.isBlock) {

--- a/src/node.ts
+++ b/src/node.ts
@@ -85,12 +85,17 @@ export class Node {
 
   /// Concatenates all the text nodes found in this fragment and its
   /// children.
-  get textContent() { return this.textBetween(0, this.content.size, "") }
+  get textContent() {
+    return (this.isLeaf && this.type.spec.toText)
+      ? this.type.spec.toText(this)
+      : this.textBetween(0, this.content.size, "")
+  }
 
   /// Get all text between positions `from` and `to`. When
   /// `blockSeparator` is given, it will be inserted to separate text
-  /// from different block nodes. When `leafText` is given, it'll be
-  /// inserted for every non-text leaf node encountered.
+  /// from different block nodes. If `leafText` is given, it'll be
+  /// inserted for every non-text leaf node encountered, otherwise
+  /// [`toText`](#model.NodeSpec^toText) will be used.
   textBetween(from: number, to: number, blockSeparator?: string | null,
               leafText?: null | string | ((leafNode: Node) => string)) {
     return this.content.textBetween(from, to, blockSeparator, leafText)

--- a/src/node.ts
+++ b/src/node.ts
@@ -86,8 +86,8 @@ export class Node {
   /// Concatenates all the text nodes found in this fragment and its
   /// children.
   get textContent() {
-    return (this.isLeaf && this.type.spec.toText)
-      ? this.type.spec.toText(this)
+    return (this.isLeaf && this.type.spec.leafText)
+      ? this.type.spec.leafText(this)
       : this.textBetween(0, this.content.size, "")
   }
 
@@ -95,7 +95,7 @@ export class Node {
   /// `blockSeparator` is given, it will be inserted to separate text
   /// from different block nodes. If `leafText` is given, it'll be
   /// inserted for every non-text leaf node encountered, otherwise
-  /// [`toText`](#model.NodeSpec^toText) will be used.
+  /// [`leafText`](#model.NodeSpec^leafText) will be used.
   textBetween(from: number, to: number, blockSeparator?: string | null,
               leafText?: null | string | ((leafNode: Node) => string)) {
     return this.content.textBetween(from, to, blockSeparator, leafText)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -431,7 +431,7 @@ export interface NodeSpec {
   /// this type should be serialized to a string (as used by
   /// [`Node.textBetween`](#model.Node^textBetween) and
   /// [`Node.textContent`](#model.Node^textContent)).
-  toText?: (node: Node) => string
+  leafText?: (node: Node) => string
 
   /// Node specs may include arbitrary properties that can be read by
   /// other code via [`NodeType.spec`](#model.NodeType.spec).

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -427,6 +427,12 @@ export interface NodeSpec {
   /// to a string representation for debugging (e.g. in error messages).
   toDebugString?: (node: Node) => string
 
+  /// Defines the default way a [leaf node](#model.NodeType.isLeaf) of
+  /// this type should be serialized to a string (as used by
+  /// [`Node.textBetween`](#model.Node^textBetween) and
+  /// [`Node.textContent`](#model.Node^textContent)).
+  toText?: (node: Node) => string
+
   /// Node specs may include arbitrary properties that can be read by
   /// other code via [`NodeType.spec`](#model.NodeType.spec).
   [key: string]: any

--- a/test/test-node.ts
+++ b/test/test-node.ts
@@ -10,7 +10,7 @@ let customSchema = new Schema({
     contact: {
       inline: true,
       attrs: { name: {}, email: {} },
-      toText(node: Node) { return `${node.attrs.name} <${node.attrs.email}>` }
+      leafText(node: Node) { return `${node.attrs.name} <${node.attrs.email}>` }
     },
     hard_break: { toDebugString() { return 'custom_hard_break' } }
   },
@@ -101,7 +101,7 @@ describe("Node", () => {
       }), 'foo<image><break>')
     })
 
-    it("works with toText", () => {
+    it("works with leafText", () => {
       const d = customSchema.nodes.doc.createChecked({}, [
         customSchema.nodes.paragraph.createChecked({}, [
           customSchema.text("Hello "),
@@ -111,7 +111,7 @@ describe("Node", () => {
       ist(d.textBetween(0, d.content.size), 'Hello Alice <alice@example.com>')
     })
 
-    it("should ignore toText when passing a custom leafText", () => {
+    it("should ignore leafText when passing a custom leafText", () => {
       const d = customSchema.nodes.doc.createChecked({}, [
         customSchema.nodes.paragraph.createChecked({}, [
           customSchema.text("Hello "),
@@ -191,7 +191,7 @@ describe("Node", () => {
     )
   })
 
-  describe("toText", () => {
+  describe("leafText", () => {
     it("should custom the textContent of a leaf node", () => {
       let contact = customSchema.nodes.contact.createChecked({ name: "Bob", email: "bob@example.com" })
       let paragraph = customSchema.nodes.paragraph.createChecked({}, [customSchema.text('Hello '), contact])


### PR DESCRIPTION
Add a new property `toText` to NodeSpec. This property will be used to customize the text content of a leaf node when using [textContent](https://prosemirror.net/docs/ref/#model.Node.textContent) and [textBetween](https://prosemirror.net/docs/ref/#model.Node.textBetween). 

Before this PR, I wasn't able to customize the text of a leaf node when using `node.textContent` (because it doesn't accept parameters), and I need to pass the `leafText` parameter for every call to `textBetween`. This PR makes it easier to customize the textContent of leaf nodes. 
