### PR TITLE
always ensure text nodes with the same marks are joined together in a fragment

### DIFF
--- a/test/test-node.ts
+++ b/test/test-node.ts
@@ -183,7 +183,7 @@ describe("Node", () => {
 
     it("should be respected by Fragment", () =>
       ist(
-        Fragment.fromArray(
+        new Fragment(
           [customSchema.text("hello"), customSchema.nodes.hard_break.createChecked(), customSchema.text("world")]
         ),
         "<custom_text, custom_hard_break, custom_text>"


### PR DESCRIPTION
Noticed a discrepancy between `Fragment.from` and `Fragment.fromJSON`: `fromJSON` does not always ensure text nodes with the same marks are joined together in a fragment.

A simple fix would be

```diff
  static fromJSON(schema, value) {
    if (!value) return Fragment.empty
    if (!Array.isArray(value)) throw new RangeError("Invalid input for Fragment.fromJSON")
-   return new Fragment(value.map(schema.nodeFromJSON))
+   return Fragment.fromArray(value.map(schema.nodeFromJSON))
  }
```

but might as well make this behavior consistent in all `Fragments` instances by running the joining logic in the constructor, and de-duping it elsewhere.