### PR TITLE
join text nodes with the same marks when deserializing fragment from json

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -223,7 +223,7 @@ export class Fragment {
   static fromJSON(schema: Schema, value: any) {
     if (!value) return Fragment.empty
     if (!Array.isArray(value)) throw new RangeError("Invalid input for Fragment.fromJSON")
-    return new Fragment(value.map(schema.nodeFromJSON))
+    return Fragment.fromArray(value.map(schema.nodeFromJSON))
   }
 
   /// Build a fragment from an array of nodes. Ensures that adjacent


### PR DESCRIPTION
non-breaking, simpler patch of #68 only pertaining to json deserializing