### PR TITLE
Change the array type in DOMOutputSpec to readonly

### DIFF
--- a/src/to_dom.ts
+++ b/src/to_dom.ts
@@ -20,7 +20,7 @@ import {DOMNode} from "./dom"
 /// where a node's child nodes should be inserted. If it occurs in an
 /// output spec, it should be the only child element in its parent
 /// node.
-export type DOMOutputSpec = string | DOMNode | {dom: DOMNode, contentDOM?: HTMLElement} | [string, ...any[]]
+export type DOMOutputSpec = string | DOMNode | {dom: DOMNode, contentDOM?: HTMLElement} | readonly [string, ...any[]]
 
 /// A DOM serializer knows how to convert ProseMirror nodes and
 /// marks of various types to DOM nodes.


### PR DESCRIPTION
<img width="762" alt="image" src="https://user-images.githubusercontent.com/17680884/180924822-98faf0b8-fad3-43c9-a0c0-e58ecc6f20c9.png">

As shown above, I think that the type of `toDOM2` is assignable to `DOMOutputSpec`，but in the current version it is not assignable .

Would it be better to add a readonly array type for `DOMOutputSpec`?