### PR TITLE
Make TextNode public

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {Node} from "./node"
+export {Node, TextNode} from "./node"
 export {ResolvedPos, NodeRange} from "./resolvedpos"
 export {Fragment} from "./fragment"
 export {Slice, ReplaceError} from "./replace"


### PR DESCRIPTION
Exposing `TextNode` so it can be used in [scenarios like](https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/from_markdown.ts#LL9C50-L9C50):

```
// prosemirror-markdown:src/from_markdown.ts
function maybeMerge(a: Node, b: Node): Node | undefined {
  if (a.isText && b.isText && Mark.sameSet(a.marks, b.marks))
    return (a as any).withText(a.text! + b.text!)
}
```

I can change it to `export type {TextNode} from "./node"` if you prefer not exposing it as a public API.