### PR TITLE
Improve parser performance by 50%

### DIFF
--- a/src/from_dom.ts
+++ b/src/from_dom.ts
@@ -810,11 +810,12 @@ class ParseContext {
   generateMatchers(dom: HTMLElement, rules: ParseRule[]) {
     for (const rule of rules) {
       if (!rule.tag) continue
-      if (blockTags[rule.tag] || listTags[rule.tag])
+      if (blockTags[rule.tag] || listTags[rule.tag]) {
+        const upperCaseTag = rule.tag.toUpperCase()
         // for simple selectors like li, p etc. we can just do a simple
         // tag name check.
-        this.matchers[rule.tag] = (node) => node.tagName === rule.tag
-      else {
+        this.matchers[rule.tag] = (node) => node.tagName === upperCaseTag
+      } else {
         // for more complex selectors, we collect all the matching nodes
         // just once instead of calling `matches` over and over again for
         // each node.


### PR DESCRIPTION
This PR significantly improves `parse` & `parseSlice` performance by optimizing how Prosemirror does tag matching:

1. Running `querySelectorAll` on the main dom node once instead of calling `matches` on each node individually
2. Using a simple condition for tag name selectors like `li`, `p` etc. This avoids calling any browser API and works much faster.

These changes shouldn't break anything.

## Benchmarks

### Before:
![Screenshot 2024-04-05 172532](https://github.com/ProseMirror/prosemirror-model/assets/7473959/dff9f996-8339-4a1b-8630-def3c8f0ba28)

### After:
![image](https://github.com/ProseMirror/prosemirror-model/assets/7473959/57446045-aab9-411b-9391-e5781da3f504)

That's a solid ~40% improvement.