### PR TITLE
Include type and attribute name in validate error messages

### DIFF
--- a/test/test-node.ts
+++ b/test/test-node.ts
@@ -167,7 +167,7 @@ describe("Node", () => {
 
     it("notices wrong attribute types", () => {
       ist.throws(() => schema.nodes.image.create({src: true}).check(),
-                 /Expected value of type string, got boolean/)
+                 /Expected value of type string for attribute src on type image, got boolean/)
     })
   })
 


### PR DESCRIPTION
I found it might be hard to debug validate errors like "Expected value of type string, got boolean". This PR adds the attribute name and node/mark type name to the error message, which should make debugging a lot easier. 