### PR TITLE
Add blockArraysIn to renderSpec function, which is called from prosemirror-view

### DIFF
--- a/src/to_dom.ts
+++ b/src/to_dom.ts
@@ -114,7 +114,6 @@ export class DOMSerializer {
   static renderSpec(doc: Document, structure: DOMOutputSpec, xmlNS: string | null = null, blockArraysIn?: {[name: string]: any}): {
     dom: DOMNode,
     contentDOM?: HTMLElement,
-    blockArraysIn?: {[name: string]: any}
   } {
     return renderSpec(doc, structure, xmlNS, blockArraysIn)
   }

--- a/src/to_dom.ts
+++ b/src/to_dom.ts
@@ -111,11 +111,12 @@ export class DOMSerializer {
   /// Render an [output spec](#model.DOMOutputSpec) to a DOM node. If
   /// the spec has a hole (zero) in it, `contentDOM` will point at the
   /// node with the hole.
-  static renderSpec(doc: Document, structure: DOMOutputSpec, xmlNS: string | null = null): {
+  static renderSpec(doc: Document, structure: DOMOutputSpec, xmlNS: string | null = null, blockArraysIn?: {[name: string]: any}): {
     dom: DOMNode,
-    contentDOM?: HTMLElement
+    contentDOM?: HTMLElement,
+    blockArraysIn?: {[name: string]: any}
   } {
-    return renderSpec(doc, structure, xmlNS)
+    return renderSpec(doc, structure, xmlNS, blockArraysIn)
   }
 
   /// Build a serializer using the [`toDOM`](#model.NodeSpec.toDOM)

--- a/src/to_dom.ts
+++ b/src/to_dom.ts
@@ -113,7 +113,7 @@ export class DOMSerializer {
   /// node with the hole.
   static renderSpec(doc: Document, structure: DOMOutputSpec, xmlNS: string | null = null, blockArraysIn?: {[name: string]: any}): {
     dom: DOMNode,
-    contentDOM?: HTMLElement,
+    contentDOM?: HTMLElement
   } {
     return renderSpec(doc, structure, xmlNS, blockArraysIn)
   }


### PR DESCRIPTION
Adds `blocksArraysIn` parameter to the `renderSpec()` function in order to support the check for XSS on initial document load. A follow up [PR](https://github.com/ProseMirror/prosemirror-view/pull/169) in prosemirror-view will be created to support this change.