### PR TITLE
Adding map functions to Node and Fragment

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -204,6 +204,11 @@ export class Fragment {
     }
   }
 
+  /// Calling `f` over each child node and returning a new fragment.
+  map(f: ((Node) => Node)): Fragment {
+    return new Fragment(this.content.map(node => f(node)));
+  }
+
   /// Return a debugging string that describes this fragment.
   toString(): string { return "<" + this.toStringInner() + ">" }
 

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -205,8 +205,8 @@ export class Fragment {
   }
 
   /// Calling `f` over each child node and returning a new fragment.
-  map(f: ((Node) => Node)): Fragment {
-    return new Fragment(this.content.map(node => f(node)));
+  map(f: ((node: Node) => Node)): Fragment {
+    return new Fragment(this.content.map(f));
   }
 
   /// Return a debugging string that describes this fragment.

--- a/src/node.ts
+++ b/src/node.ts
@@ -147,7 +147,7 @@ export class Node {
   /// and updated Fragment of children Nodes.
   map(f: ((Node) => Node)): Node {
     const mappedFragment = this.content.map(node => f(node));
-    return new Node(this.type, this.attrs, mappedFragment, this.marks);
+    return this.copy(mappedFragment);
   }
 
   /// Create a copy of this node with only the content between the

--- a/src/node.ts
+++ b/src/node.ts
@@ -145,8 +145,8 @@ export class Node {
   /// Call `f` for every child node, passing the node, and
   /// returning a new Node with the same type, attrs, and marks
   /// and updated Fragment of children Nodes.
-  map(f: ((Node) => Node)): Node {
-    const mappedFragment = this.content.map(node => f(node));
+  map(f: ((node: Node) => Node)): Node {
+    const mappedFragment = this.content.map(f);
     return this.copy(mappedFragment);
   }
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -67,10 +67,10 @@ export class Node {
   /// Invoke a callback for all descendant nodes recursively between
   /// the given two positions that are relative to start of this
   /// node's content. The callback is invoked with the node, its
-  /// position relative to the original node (method receiver), 
+  /// position relative to the original node (method receiver),
   /// its parent node, and its child index. When the callback returns
   /// false for a given node, that node's children will not be
-  /// recursed over. The last parameter can be used to specify a 
+  /// recursed over. The last parameter can be used to specify a
   /// starting position to count from.
   nodesBetween(from: number, to: number,
                f: (node: Node, pos: number, parent: Node | null, index: number) => void | boolean,
@@ -140,6 +140,14 @@ export class Node {
   /// of the node's own marks.
   mark(marks: readonly Mark[]): Node {
     return marks == this.marks ? this : new Node(this.type, this.attrs, this.content, marks)
+  }
+
+  /// Call `f` for every child node, passing the node, and
+  /// returning a new Node with the same type, attrs, and marks
+  /// and updated Fragment of children Nodes.
+  map(f: ((Node) => Node)): Node {
+    const mappedFragment = this.content.map(node => f(node));
+    return new Node(this.type, this.attrs, mappedFragment, this.marks);
   }
 
   /// Create a copy of this node with only the content between the


### PR DESCRIPTION
Adding map functions to be able to map over children nodes in the Node and Fragment classes.

The impetus for this is if you want to modify the child nodes in a non mutation way, you need to call `forEach` on a `Node` and push those Node's onto an array, and then make your modifications to those child nodes. The same goes for fragments.

The documentation in Fragment even states:

> /// Like nodes, fragments are persistent data structures, and you
/// should not mutate them or their content. Rather, you create new
/// instances whenever needed. The API tries to make this easy.
export class Fragment {

This way, instead of using `forEach` we can just map over child nodes and get a new object in return. I think this also provides a cleaner way to make non-mutative changes in a syntactically cleaner style.

I didn't create an RFC just because it's a minor change.