### PR TITLE
Add filterAttrs parameter to toJSON methods

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -1,6 +1,6 @@
 import {findDiffStart, findDiffEnd} from "./diff"
 import {Node, TextNode} from "./node"
-import {Schema} from "./schema"
+import {Attrs, Schema} from "./schema"
 
 /// A fragment represents a node's collection of child nodes.
 ///
@@ -211,8 +211,8 @@ export class Fragment {
   toStringInner() { return this.content.join(", ") }
 
   /// Create a JSON-serializeable representation of this fragment.
-  toJSON(): any {
-    return this.content.length ? this.content.map(n => n.toJSON()) : null
+  toJSON(filterAttrs?: (attrs: Attrs) => Attrs): any {
+    return this.content.length ? this.content.map(n => n.toJSON(filterAttrs)) : null
   }
 
   /// Deserialize a fragment from its JSON representation.

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -68,9 +68,10 @@ export class Mark {
   }
 
   /// Convert this mark to a JSON-serializeable representation.
-  toJSON(): any {
+  toJSON(filterAttrs?: (attrs: Attrs) => Attrs): any {
     let obj: any = {type: this.type.name}
-    for (let _ in this.attrs) {
+    let attrs = filterAttrs ? filterAttrs(this.attrs) : this.attrs
+    for (let _ in attrs) {
       obj.attrs = this.attrs
       break
     }

--- a/src/node.ts
+++ b/src/node.ts
@@ -315,16 +315,17 @@ export class Node {
   }
 
   /// Return a JSON-serializeable representation of this node.
-  toJSON(): any {
+  toJSON(filterAttrs?: (attrs: Attrs) => Attrs): any {
     let obj: any = {type: this.type.name}
-    for (let _ in this.attrs) {
-      obj.attrs = this.attrs
+    let attrs = filterAttrs ? filterAttrs(this.attrs) : this.attrs
+    for (let _ in attrs) {
+      obj.attrs = attrs
       break
     }
     if (this.content.size)
-      obj.content = this.content.toJSON()
+      obj.content = this.content.toJSON(filterAttrs)
     if (this.marks.length)
-      obj.marks = this.marks.map(n => n.toJSON())
+      obj.marks = this.marks.map(n => n.toJSON(filterAttrs))
     return obj
   }
 
@@ -388,8 +389,8 @@ export class TextNode extends Node {
     return this.sameMarkup(other) && this.text == other.text
   }
 
-  toJSON() {
-    let base = super.toJSON()
+  toJSON(filterAttrs?: (attrs: Attrs) => Attrs) {
+    let base = super.toJSON(filterAttrs)
     base.text = this.text
     return base
   }

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -1,5 +1,5 @@
 import {Fragment} from "./fragment"
-import {Schema} from "./schema"
+import {Attrs, Schema} from "./schema"
 import {Node, TextNode} from "./node"
 import {ResolvedPos} from "./resolvedpos"
 
@@ -68,9 +68,9 @@ export class Slice {
   }
 
   /// Convert a slice to a JSON-serializable representation.
-  toJSON(): any {
+  toJSON(filterAttrs?: (attrs: Attrs) => Attrs): any {
     if (!this.content.size) return null
-    let json: any = {content: this.content.toJSON()}
+    let json: any = {content: this.content.toJSON(filterAttrs)}
     if (this.openStart > 0) json.openStart = this.openStart
     if (this.openEnd > 0) json.openEnd = this.openEnd
     return json

--- a/test/test-node.ts
+++ b/test/test-node.ts
@@ -1,5 +1,5 @@
 import ist from "ist"
-import {Fragment, Schema, Node} from "prosemirror-model"
+import {Fragment, Schema, Node, Attrs} from "prosemirror-model"
 import {schema, eq, doc, blockquote, p, li, ul, em, strong, code, a, br, hr, img} from "prosemirror-test-builder"
 
 let customSchema = new Schema({
@@ -193,8 +193,8 @@ describe("Node", () => {
   })
 
   describe("toJSON", () => {
-    function roundTrip(doc: Node) {
-      ist(schema.nodeFromJSON(doc.toJSON()), doc, eq)
+    function roundTrip(doc: Node, filterAttrs?: (attrs: Attrs) => Attrs) {
+      ist(schema.nodeFromJSON(doc.toJSON(filterAttrs)), doc, eq)
     }
 
     it("can serialize a simple node", () => roundTrip(doc(p("foo"))))
@@ -206,6 +206,12 @@ describe("Node", () => {
     it("can serialize block leaf nodes", () => roundTrip(doc(p("a"), hr(), p("b"), p())))
 
     it("can serialize nested nodes", () => roundTrip(doc(blockquote(ul(li(p("a"), p("b")), li(p(img()))), p("c")), p("d"))))
+
+    it("can serialize nested nodes with filterAttrs", () => roundTrip(doc(blockquote(ul(li(p("a"), p("b")), li(p(img()))), p("c")), p("d")), attrs => {
+      return Object.fromEntries(
+        Object.entries(attrs).filter(([_, value]) => value != null)
+      );
+    }))
   })
 
   describe("toString", () => {


### PR DESCRIPTION
Support to filter useless attrs, like undefind or null
```
doc.toJSON(attrs => _.omitBy(attrs, _. isNil))
```