### PR TITLE
Correct some link fragments

### DIFF
--- a/src/from_dom.ts
+++ b/src/from_dom.ts
@@ -40,7 +40,7 @@ export interface ParseOptions {
   topMatch?: ContentMatch
 
   /// A set of additional nodes to count as
-  /// [context](#model.ParseRule.context) when parsing, above the
+  /// [context](#model.GenericParseRule.context) when parsing, above the
   /// given [top node](#model.ParseOptions.topNode).
   context?: ResolvedPos
 
@@ -148,9 +148,9 @@ export interface StyleParseRule extends GenericParseRule {
   /// that list that property. May also have the form
   /// `"property=value"`, in which case the rule only matches if the
   /// property's value exactly matches the given value. (For more
-  /// complicated filters, use [`getAttrs`](#model.ParseRule.getAttrs)
+  /// complicated filters, use [`getAttrs`](#model.StyleParseRule.getAttrs)
   /// and return false to indicate that the match failed.) Rules
-  /// matching styles may only produce [marks](#model.ParseRule.mark),
+  /// matching styles may only produce [marks](#model.GenericParseRule.mark),
   /// not nodes.
   style: string
 
@@ -303,7 +303,7 @@ export class DOMParser {
 
   /// Construct a DOM parser using the parsing rules listed in a
   /// schema's [node specs](#model.NodeSpec.parseDOM), reordered by
-  /// [priority](#model.ParseRule.priority).
+  /// [priority](#model.GenericParseRule.priority).
   static fromSchema(schema: Schema) {
     return schema.cached.domParser as DOMParser ||
       (schema.cached.domParser = new DOMParser(schema, DOMParser.schemaRules(schema)))

--- a/src/node.ts
+++ b/src/node.ts
@@ -99,7 +99,7 @@ export class Node {
   /// `blockSeparator` is given, it will be inserted to separate text
   /// from different block nodes. If `leafText` is given, it'll be
   /// inserted for every non-text leaf node encountered, otherwise
-  /// [`leafText`](#model.NodeSpec^leafText) will be used.
+  /// [`leafText`](#model.NodeSpec.leafText) will be used.
   textBetween(from: number, to: number, blockSeparator?: string | null,
               leafText?: null | string | ((leafNode: Node) => string)) {
     return this.content.textBetween(from, to, blockSeparator, leafText)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -446,7 +446,7 @@ export interface NodeSpec {
 
   /// Defines the default way a node of this type should be serialized
   /// to DOM/HTML (as used by
-  /// [`DOMSerializer.fromSchema`](#model.DOMSerializer^fromSchema)).
+  /// [`DOMSerializer.fromSchema`](#model.DOMSerializer.fromSchema)).
   /// Should return a DOM node or an [array
   /// structure](#model.DOMOutputSpec) that describes one, with an
   /// optional number zero (“hole”) in it to indicate where the node's
@@ -459,7 +459,7 @@ export interface NodeSpec {
   toDOM?: (node: Node) => DOMOutputSpec
 
   /// Associates DOM parser information with this node, which can be
-  /// used by [`DOMParser.fromSchema`](#model.DOMParser^fromSchema) to
+  /// used by [`DOMParser.fromSchema`](#model.DOMParser.fromSchema) to
   /// automatically derive a parser. The `node` field in the rules is
   /// implied (the name of this node will be filled in automatically).
   /// If you supply your own parser, you do not need to also specify
@@ -472,8 +472,8 @@ export interface NodeSpec {
 
   /// Defines the default way a [leaf node](#model.NodeType.isLeaf) of
   /// this type should be serialized to a string (as used by
-  /// [`Node.textBetween`](#model.Node^textBetween) and
-  /// [`Node.textContent`](#model.Node^textContent)).
+  /// [`Node.textBetween`](#model.Node.textBetween) and
+  /// [`Node.textContent`](#model.Node.textContent)).
   leafText?: (node: Node) => string
 
   /// A single inline node in a schema can be set to be a linebreak


### PR DESCRIPTION
Some links in the `.d.ts` files don't locate any `id`. Two examples are shown below:


<img width="1414" alt="image" src="https://github.com/user-attachments/assets/5eb71221-de71-4e90-8907-60ed769de476" />
 
---

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/c18070ab-a329-4770-a27e-23af2deb5408" />

