### PR TITLE
Correct some link fragments in doc comments

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -446,7 +446,7 @@ export interface NodeSpec {
 
   /// Defines the default way a node of this type should be serialized
   /// to DOM/HTML (as used by
-  /// [`DOMSerializer.fromSchema`](#model.DOMSerializer.fromSchema)).
+  /// [`DOMSerializer.fromSchema`](#model.DOMSerializer^fromSchema)).
   /// Should return a DOM node or an [array
   /// structure](#model.DOMOutputSpec) that describes one, with an
   /// optional number zero (“hole”) in it to indicate where the node's
@@ -459,7 +459,7 @@ export interface NodeSpec {
   toDOM?: (node: Node) => DOMOutputSpec
 
   /// Associates DOM parser information with this node, which can be
-  /// used by [`DOMParser.fromSchema`](#model.DOMParser.fromSchema) to
+  /// used by [`DOMParser.fromSchema`](#model.DOMParser^fromSchema) to
   /// automatically derive a parser. The `node` field in the rules is
   /// implied (the name of this node will be filled in automatically).
   /// If you supply your own parser, you do not need to also specify


### PR DESCRIPTION
I realize that I made some mistake in my previous PR https://github.com/ProseMirror/prosemirror-model/pull/89. In ProseMirror's docs, all _static_ methods have `^` in their link anchor. This PR fixes two links in the docs.

<img width="708" height="343" alt="image" src="https://github.com/user-attachments/assets/be54849b-5b05-4d96-a62d-53c9c3df7f33" />


Just FYI, I'm using the [lychee](https://github.com/lycheeverse/lychee) CLI to find incorrect links:

```bash
$ lychee --include-fragments https://prosemirror.net/docs/ref/
  221/221 ━━━━━━━━━━━━━━━━━━━━ Finished extracting links                                                                                                                     Issues found in 1 input. Find details below.

[https://prosemirror.net/docs/ref/]:
   [ERROR] https://prosemirror.net/docs/ref/#model.DOMParser.fromSchema | Cannot find fragment
   [ERROR] https://prosemirror.net/docs/ref/#model.DOMSerializer.fromSchema | Cannot find fragment

🔍 221 Total (in 6s) ✅ 219 OK 🚫 2 Errors
```