### PR TITLE
Fix array bounds vulnerability in Fragment iteration methods

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -30,7 +30,7 @@ export class Fragment {
                f: (node: Node, start: number, parent: Node | null, index: number) => boolean | void,
                nodeStart = 0,
                parent?: Node) {
-    for (let i = 0, pos = 0; pos < to; i++) {
+    for (let i = 0, pos = 0; pos < to && i < this.content.length; i++) {
       let child = this.content[i], end = pos + child.nodeSize
       if (end > from && f(child, nodeStart + pos, parent || null, i) !== false && child.content.size) {
         let start = pos + 1
@@ -86,7 +86,7 @@ export class Fragment {
   cut(from: number, to = this.size) {
     if (from == 0 && to == this.size) return this
     let result: Node[] = [], size = 0
-    if (to > from) for (let i = 0, pos = 0; pos < to; i++) {
+    if (to > from) for (let i = 0, pos = 0; pos < to && i < this.content.length; i++) {
       let child = this.content[i], end = pos + child.nodeSize
       if (end > from) {
         if (pos < from || end > to) {

--- a/test/test-node.ts
+++ b/test/test-node.ts
@@ -62,6 +62,12 @@ describe("Node", () => {
     it("preserves marks", () =>
        cut(doc(p("foo", em("ba<a>r", img(), strong("baz"), br()), "qu<b>ux", code("xyz"))),
            doc(p(em("r", img(), strong("baz"), br()), "qu"))))
+
+    it("handles to parameter exceeding fragment size", () => {
+      const doc = p("foo")
+      const result = doc.cut(0, 1000)
+      ist(result.content.size, doc.content.size)
+    })
   })
 
   describe("between", () => {
@@ -89,6 +95,13 @@ describe("Node", () => {
     it("iterates over inline nodes", () =>
        between(doc(p(em("x"), "f<a>oo", em("bar", img(), strong("baz"), br()), "quux", code("xy<b>z"))),
                "paragraph", "foo", "bar", "image", "baz", "hard_break", "quux", "xyz"))
+
+    it("handles to parameter exceeding fragment size", () => {
+      const doc = p("foo")
+      let count = 0
+      doc.nodesBetween(0, 1000, () => { count++ })
+      ist(count > 0)
+    })
   })
 
   describe("textBetween", () => {


### PR DESCRIPTION
Fragment.nodesBetween() and Fragment.cut() both contain unsafe loop conditions that can cause out-of-bounds array access when the 'to' parameter exceeds the fragment's actual size. This is a defensive programming failure that violates the principle that interfaces should be safe against invalid input.

The fix adds proper bounds checking to prevent accessing this.content[i] when i >= this.content.length. This ensures the methods remain robust even when called with parameters that exceed the fragment bounds.

Added tests to verify the edge case behavior.